### PR TITLE
fix normfactor for low number of genesets (fix issue #6)

### DIFF
--- a/R/plaid.R
+++ b/R/plaid.R
@@ -148,8 +148,8 @@ plaid <- function(X, matG, stats=c("mean","sum"), chunk=NULL, normalize=TRUE,
   if(normalize) {
     if(nrow(gsetX) < 20) {
       ## for few genesets, median-norm is not good
-      normfactor <- log2(colSums(2**X,na.rm=TRUE))
-      normfactor <- normfactor + mean(normfactor)
+      normfactor <- Matrix::colMeans(gsetX,na.rm=TRUE)
+      normfactor <- normfactor - mean(normfactor)
       gsetX <- sweep(gsetX, 2, normfactor, '-') 
     } else {
       gsetX <- normalize_medians(gsetX)


### PR DESCRIPTION
(fix issue #6)

For less than 20 genesets normalization was assumed as "RNAseq" with total counts after exp2. This is not general applilcable especially when using replaid.ucell where X as ranks and exp2 will overflow.  Normalization for < 20 genesets is now set as 'mean' normalization instead of the default 'median' normalization for N>20.